### PR TITLE
Narrow scope of ACME protocol redirects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ RUN mkdir /python
 RUN apk add --no-cache gcc py-pip python-dev musl-dev libffi-dev openssl-dev linux-headers openssl libffi
 
 COPY requirements.txt /python
-COPY rancher.py /python
 RUN pip install -r /python/requirements.txt
+COPY rancher.py /python
 RUN mkdir -p /var/www/
 
 ENTRYPOINT /python/rancher.py

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The service launches two containers:
 - `letsencrypt-nginx`
 - `letsencrypt-python`
 
-The `letsencrypt-nginx` container is stock nginx, but shares the webroot with the `letsencrypt-python` service container. This way the `letsencrypt-python` container can add ACME challenges to the `<host>/.well-known/acme-challenges/` directory on the webserver for verification. The python container is a sidekick of the nginx container. The containers are launched as a Rancher Service Account, so special environment variables containing the Rancher server API url, and access keys are passed into the container at runtime. 
+The `letsencrypt-nginx` container is stock nginx, but shares the webroot with the `letsencrypt-python` service container. This way the `letsencrypt-python` container can add ACME challenges to the `<host>/.well-known/acme-challenge/` directory on the webserver for verification. The python container is a sidekick of the nginx container. The containers are launched as a Rancher Service Account, so special environment variables containing the Rancher server API url, and access keys are passed into the container at runtime. 
 
 ## Requirements
 
@@ -24,7 +24,7 @@ The `letsencrypt-nginx` container is stock nginx, but shares the webroot with th
 
 ## How to use
 
-Create a front end load balancer (or use the one in `traffic-manager` directory). If you are making one, you need to make sure it is a L7 HTTP load balancer on port 80. This way the load balancer can redirect /.well-known/\* traffic to the `letsencrypt-nginx` container for verification. You can then route all other traffic to your normal HTTP services. This way only during verification does traffic get directed to the `letsencrypt-nginx` container. Use `rancher-compose up` to launch the stack in rancher. **In order to get a Let's Encrypt Production certificate, you must set the environment variable STAGING=False**. This will then tell the service to use the production Let's Encrypt api instead of the staging api.
+Create a front end load balancer (or use the one in `traffic-manager` directory). If you are making one, you need to make sure it is a L7 HTTP load balancer on port 80. This way the load balancer can redirect /.well-known/acme-challenge/\* traffic to the `letsencrypt-nginx` container for verification. You can then route all other traffic to your normal HTTP services. This way only during verification does traffic get directed to the `letsencrypt-nginx` container. Use `rancher-compose up` to launch the stack in rancher. **In order to get a Let's Encrypt Production certificate, you must set the environment variable STAGING=False**. This will then tell the service to use the production Let's Encrypt api instead of the staging api.
 
 # Certificate Workflows
 

--- a/rancher.py
+++ b/rancher.py
@@ -367,12 +367,12 @@ class RancherService:
                     print "Hostname: {0} resolves".format(host)
                     if(self.port_open(host, HOST_CHECK_PORT)):
                         print "\tPort {0} open on {1}".format(HOST_CHECK_PORT, host)
-                        # check if the /.well-known/ directory isn't returning a 301 redirect
+                        # check if the /.well-known/acme-challenge/ directory isn't returning a 301 redirect
                         # this is caused by the rancher load balancer not picking up the lets-encrypt service
                         # and not directing traffic to it. Instead the redirection service gets the requests and returns
                         # a 301 redirect. Also, if we get a 503 service unavailable status code there is no lets-encrypt nginx
                         # container working, and we should continue to wait and NOT requests Let's Encrypt certificates yet.
-                        url = "http://{0}/.well-known/:{1}".format(host, HOST_CHECK_PORT)
+                        url = "http://{0}/.well-known/acme-challenge/:{1}".format(host, HOST_CHECK_PORT)
                         r = requests.get(url, allow_redirects=False)
                         if(r.status_code != 503 and r.status_code != 301):
                             print "\t\tOK, got HTTP status code ({0}) for ({1})".format(r.status_code, host)

--- a/traffic-manager/docker-compose.yml
+++ b/traffic-manager/docker-compose.yml
@@ -6,7 +6,7 @@ traffic-manager-80:
   labels:
     io.rancher.scheduler.global: 'true'
     io.rancher.loadbalancer.target.redirect/redirect: yourdomain.example.com:80=80
-    io.rancher.loadbalancer.target.lets-encrypt/letsencrypt-nginx: yourdomain.example.com:80/.well-known/=80,anotherdomain.example.com:80/.well-known/=80
+    io.rancher.loadbalancer.target.lets-encrypt/letsencrypt-nginx: yourdomain.example.com:80/.well-known/acme-challenge/=80,anotherdomain.example.com:80/.well-known/acme-challenge/=80
   tty: true
   image: rancher/load-balancer-service
   stdin_open: true


### PR DESCRIPTION
The .well-known path is RFC5785 and is not just for Let’s Encrypt/ACME.

Typo in README.md acme-challenges should read acme-challenge
