### PR TITLE
handle environment with very many certificates

### DIFF
--- a/files/rancher.py
+++ b/files/rancher.py
@@ -75,7 +75,7 @@ class RancherService:
         """
         return json(python dict) of certificate listing api endpoint
         """
-        url = "{0}/certificate".format(RANCHER_URL)
+        url = "{0}/certificate?limit=1000".format(RANCHER_URL)
         # make sure we loop until we get valid data back from server
         done = False
         while not done:


### PR DESCRIPTION
We have an environment with a large number of certificates. The python script is not iterating over the pages of certificates returned by the rancher API. As simple fix I just set the page limit to 1000 to handle all certificates. Without the fix post_cert tries to create certificates instead of updating them which results in an error.