### PR TITLE
Upgrade dependency pyOpenSSL to 23.1.1

### DIFF
--- a/files/requirements.txt
+++ b/files/requirements.txt
@@ -2,4 +2,4 @@ argcomplete==1.10.0
 requests==2.22.0
 certbot==1.15.0
 acme==1.15.0
-pyOpenSSL==19.0.0
+pyOpenSSL==23.1.1


### PR DESCRIPTION
Building the container from main causes the container to fail to start with the following error:

```
AttributeError: module 'lib' has no attribute 'X509_V_FLAG_NOTIFY_POLICY'
```

[It seems that it is a somewhat known issue](https://stackoverflow.com/questions/73830524/attributeerror-module-lib-has-no-attribute-x509-v-flag-cb-issuer-check) that is resolved by pinning the version to 23.1.1

Can't pin any higher due to https://serverfault.com/questions/1132420/invalid-version-when-updating-certificate-with-certbot
